### PR TITLE
support simple gain scheduling

### DIFF
--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -60,6 +60,7 @@ typedef struct
   int32_t v_ff_kp_q8;   // Feed forward P gain
   int32_t v_kp_q8;      // Feed back P gain
   int32_t v_ti_q8;      // Feed back I gain
+  int32_t v_gain_schedule_multiplier; // Gain multiplier
   int32_t brush_co_mv;  // Brush compensation voltage
   int32_t max_mv;       // Maximum output voltage
   int32_t max_cur;      // Maximum output current

--- a/Core/Inc/motor_profiles.h
+++ b/Core/Inc/motor_profiles.h
@@ -5,8 +5,9 @@ const static CtrlConfs MtConfDefault =
   1.f * (1<<CtrlQ),
   1.0f * (1<<CtrlQ),
   0.1f * (1<<CtrlQ),
+  10,
   300,
-  12000,
+  3000,
   3000
 };
 


### PR DESCRIPTION
簡単なゲインスケジューリングに対応。

スケジューリングは目標速度が低い場合にゲインを上げるというシンプルなもの。
手動で速度可変させる場合には問題ないが指令値を急変動させると発振の可能性があるため、目標値を自動制御する場合には目標値フィルタを導入するなどして制限をかける必要がある。